### PR TITLE
Bump js-yaml to 3.15.0 to fix merge-key DoS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7555,9 +7555,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
js-yaml <3.15.0 lets YAML merge-key chains force quadratic CPU consumption (CVE-2026-59869 / GHSA-52cp-r559-cp3m, high).

Dev-only dependency, reached through the vue-cli eslint plugins. Their ^3.13.1 range already permits the fix, so this is a lockfile-only change with no manifest edit.

Verified: npm run lint passes, npm run build succeeds, dev server renders the app with no console errors.